### PR TITLE
Update to .NET 10.0 and upgrade dependencies

### DIFF
--- a/GeneralApi/GeneralApi.csproj
+++ b/GeneralApi/GeneralApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>a450d718-b21f-416d-8d88-c7486ff34999</UserSecretsId>
@@ -12,15 +12,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Airtable" Version="1.7.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.10"/>
-        <PackageReference Include="System.Text.Json" Version="9.0.10"/>
+        <PackageReference Include="Airtable" Version="1.8.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ApiSourceGenerator\ApiSourceGenerator.csproj" OutputItemType="Analyzer"/>
+        <ProjectReference Include="..\ApiSourceGenerator\ApiSourceGenerator.csproj" OutputItemType="Analyzer" />
     </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "rollForward": "latestMinor",
-    "version": "9.0.306"
+    "version": "10.0.100"
   }
 }


### PR DESCRIPTION
Updated the target framework in `GeneralApi.csproj` from `.NET 9.0` to `.NET 10.0`. Upgraded NuGet package dependencies:
- `Airtable` to version `1.8.0`
- `Microsoft.AspNetCore.OpenApi` to version `10.0.0`
- `Swashbuckle.AspNetCore` to version `10.0.1`

Removed `Microsoft.AspNetCore.Components.Web` and `System.Text.Json` package references. Updated `global.json` to use .NET SDK version `10.0.100`. Retained `rollForward` policy as `latestMinor` and `allowPrerelease` as `false`. Minor formatting adjustments made to `ProjectReference` in `GeneralApi.csproj`.